### PR TITLE
feat: trade outcome alerts — Telegram notification when TP/SL hit

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -635,10 +635,11 @@ if __name__ == '__main__':
         # Watchdog: verify all live positions have SL protection
         if config.LIVE_TRADING_ENABLED:
             try:
-                from utils.liveTrading import watchdog_check_positions
+                from utils.liveTrading import watchdog_check_positions, monitor_trade_outcomes
                 watchdog_check_positions()
+                monitor_trade_outcomes()
             except Exception as e:
-                log_event(f"Watchdog error: {e}")
+                log_event(f"Watchdog/monitor error: {e}")
 
         log_event(f"🕒 Waiting {MAIN_LOOP_INTERVAL_SEC}s until next cycle...\n")
         for _ in range(MAIN_LOOP_INTERVAL_SEC // 10):

--- a/config.py
+++ b/config.py
@@ -57,6 +57,9 @@ LIVE_TRADING_MIN_BALANCE_USDT = 20.0     # stop opening trades if free balance d
 LIVE_TRADING_COOLDOWN_AFTER_LOSS_SEC = 1800  # 30min pause after a losing trade closes
 LIVE_TRADING_MAX_CAPITAL_DEPLOYED_PCT = 50.0  # never use more than 50% of total balance across all positions
 
+# Trade outcome alerts — Telegram notifications when TP/SL hit
+TRADE_OUTCOME_ALERTS_ENABLED = True
+
 BOT_STARTED_AT_UTC = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
 BOT_HOSTNAME = socket.gethostname()
 BOT_PID = os.getpid()

--- a/tests/test_outcome_monitor.py
+++ b/tests/test_outcome_monitor.py
@@ -1,0 +1,141 @@
+"""Tests for trade outcome monitoring in utils/liveTrading.py."""
+
+import time
+from unittest.mock import patch, MagicMock
+
+import config
+from utils.liveTrading import (
+    track_position,
+    untrack_position,
+    monitor_trade_outcomes,
+    _tracked_positions,
+)
+
+
+class TestTrackPosition:
+    def setup_method(self):
+        _tracked_positions.clear()
+
+    def teardown_method(self):
+        _tracked_positions.clear()
+
+    def test_track_adds_to_dict(self):
+        track_position("BTC/USDT:USDT", "buy", 50000, 52000, 49000, "trend", "15m")
+        assert "BTC/USDT:USDT" in _tracked_positions
+        info = _tracked_positions["BTC/USDT:USDT"]
+        assert info['side'] == "buy"
+        assert info['entry'] == 50000
+        assert info['tp'] == 52000
+        assert info['sl'] == 49000
+        assert info['strategy'] == "trend"
+        assert info['timeframe'] == "15m"
+        assert info['opened_at'] > 0
+
+    def test_untrack_removes(self):
+        track_position("BTC/USDT:USDT", "buy", 50000, 52000, 49000)
+        untrack_position("BTC/USDT:USDT")
+        assert "BTC/USDT:USDT" not in _tracked_positions
+
+    def test_untrack_nonexistent_is_safe(self):
+        untrack_position("NONEXISTENT")
+
+
+class TestMonitorTradeOutcomes:
+    def setup_method(self):
+        _tracked_positions.clear()
+        config.LIVE_TRADING_ENABLED = True
+        config.PHEMEX_API_KEY = "test"
+        config.PHEMEX_API_SECRET = "test"
+
+    def teardown_method(self):
+        _tracked_positions.clear()
+        config.LIVE_TRADING_ENABLED = False
+        config.PHEMEX_API_KEY = ""
+        config.PHEMEX_API_SECRET = ""
+
+    def test_no_tracked_positions_returns_immediately(self):
+        monitor_trade_outcomes()
+
+    @patch('utils.liveTrading.get_authenticated_exchange')
+    @patch('utils.liveTrading.get_open_positions')
+    @patch('utils.liveTrading._send_outcome_alert')
+    def test_detects_closed_position(self, mock_alert, mock_positions, mock_exchange):
+        mock_exchange.return_value = MagicMock()
+        mock_positions.return_value = []
+
+        track_position("SUI/USDT:USDT", "buy", 1.50, 1.60, 1.45, "trend", "15m")
+        assert "SUI/USDT:USDT" in _tracked_positions
+
+        monitor_trade_outcomes()
+
+        mock_alert.assert_called_once()
+        call_args = mock_alert.call_args
+        assert call_args[0][1] == "SUI/USDT:USDT"
+        assert "SUI/USDT:USDT" not in _tracked_positions
+
+    @patch('utils.liveTrading.get_authenticated_exchange')
+    @patch('utils.liveTrading.get_open_positions')
+    @patch('utils.liveTrading._send_outcome_alert')
+    def test_keeps_still_open_position(self, mock_alert, mock_positions, mock_exchange):
+        mock_exchange.return_value = MagicMock()
+        mock_positions.return_value = [{'symbol': 'SUI/USDT:USDT', 'contracts': 10}]
+
+        track_position("SUI/USDT:USDT", "buy", 1.50, 1.60, 1.45, "trend", "15m")
+
+        monitor_trade_outcomes()
+
+        mock_alert.assert_not_called()
+        assert "SUI/USDT:USDT" in _tracked_positions
+
+    @patch('utils.liveTrading.get_authenticated_exchange')
+    @patch('utils.liveTrading.get_open_positions')
+    @patch('utils.telegramUtils.send_telegram')
+    def test_outcome_alert_determines_tp(self, mock_tg, mock_positions, mock_exchange):
+        exchange_mock = MagicMock()
+        exchange_mock.fetch_ticker.return_value = {'last': 1.59}
+        mock_exchange.return_value = exchange_mock
+        mock_positions.return_value = []
+
+        track_position("SUI/USDT:USDT", "buy", 1.50, 1.60, 1.45, "trend", "15m")
+
+        monitor_trade_outcomes()
+
+        mock_tg.assert_called_once()
+        msg = mock_tg.call_args[0][0]
+        assert "TP HIT" in msg
+        assert "SUI/USDT:USDT" in msg
+
+    @patch('utils.liveTrading.get_authenticated_exchange')
+    @patch('utils.liveTrading.get_open_positions')
+    @patch('utils.telegramUtils.send_telegram')
+    def test_outcome_alert_determines_sl(self, mock_tg, mock_positions, mock_exchange):
+        exchange_mock = MagicMock()
+        exchange_mock.fetch_ticker.return_value = {'last': 1.46}
+        mock_exchange.return_value = exchange_mock
+        mock_positions.return_value = []
+
+        track_position("SUI/USDT:USDT", "buy", 1.50, 1.60, 1.45, "trend", "15m")
+
+        monitor_trade_outcomes()
+
+        mock_tg.assert_called_once()
+        msg = mock_tg.call_args[0][0]
+        assert "SL HIT" in msg
+
+    @patch('utils.liveTrading.get_authenticated_exchange')
+    @patch('utils.liveTrading.get_open_positions')
+    @patch('utils.telegramUtils.send_telegram')
+    def test_outcome_alert_short_tp(self, mock_tg, mock_positions, mock_exchange):
+        exchange_mock = MagicMock()
+        exchange_mock.fetch_ticker.return_value = {'last': 1.41}
+        mock_exchange.return_value = exchange_mock
+        mock_positions.return_value = []
+
+        track_position("SUI/USDT:USDT", "sell", 1.50, 1.40, 1.55, "range", "5m")
+
+        monitor_trade_outcomes()
+
+        mock_tg.assert_called_once()
+        msg = mock_tg.call_args[0][0]
+        assert "TP HIT" in msg
+        assert "sell" in msg.lower() or "SELL" in msg

--- a/tests/test_outcome_monitor.py
+++ b/tests/test_outcome_monitor.py
@@ -139,3 +139,47 @@ class TestMonitorTradeOutcomes:
         msg = mock_tg.call_args[0][0]
         assert "TP HIT" in msg
         assert "sell" in msg.lower() or "SELL" in msg
+
+    @patch('utils.liveTrading.get_authenticated_exchange')
+    @patch('utils.liveTrading.get_open_positions')
+    @patch('utils.telegramUtils.send_telegram')
+    def test_alerts_disabled_skips_telegram(self, mock_tg, mock_positions, mock_exchange):
+        exchange_mock = MagicMock()
+        mock_exchange.return_value = exchange_mock
+        mock_positions.return_value = []
+
+        config.TRADE_OUTCOME_ALERTS_ENABLED = False
+        track_position("SUI/USDT:USDT", "buy", 1.50, 1.60, 1.45, "trend", "15m")
+
+        monitor_trade_outcomes()
+
+        mock_tg.assert_not_called()
+        assert "SUI/USDT:USDT" not in _tracked_positions
+        config.TRADE_OUTCOME_ALERTS_ENABLED = True
+
+
+class TestAlertsCommand:
+    def setup_method(self):
+        config.TRADE_OUTCOME_ALERTS_ENABLED = True
+
+    def teardown_method(self):
+        config.TRADE_OUTCOME_ALERTS_ENABLED = True
+
+    def test_alerts_shows_status(self):
+        from utils.telegramUtils import handle_telegram_command
+        response, _ = handle_telegram_command("/alerts")
+        assert "Trade Outcome Alerts" in response
+        assert "ON" in response
+
+    def test_alerts_on(self):
+        from utils.telegramUtils import handle_telegram_command
+        config.TRADE_OUTCOME_ALERTS_ENABLED = False
+        response, _ = handle_telegram_command("/alerts on")
+        assert "ENABLED" in response
+        assert config.TRADE_OUTCOME_ALERTS_ENABLED is True
+
+    def test_alerts_off(self):
+        from utils.telegramUtils import handle_telegram_command
+        response, _ = handle_telegram_command("/alerts off")
+        assert "DISABLED" in response
+        assert config.TRADE_OUTCOME_ALERTS_ENABLED is False

--- a/utils/liveTrading.py
+++ b/utils/liveTrading.py
@@ -600,7 +600,10 @@ def monitor_trade_outcomes():
 
     for symbol in closed_symbols:
         pos_info = _tracked_positions.pop(symbol)
-        _send_outcome_alert(exchange, symbol, pos_info)
+        if config.TRADE_OUTCOME_ALERTS_ENABLED:
+            _send_outcome_alert(exchange, symbol, pos_info)
+        else:
+            log_event(f"Trade closed for {symbol} (outcome alerts disabled)")
 
 
 def _send_outcome_alert(exchange, symbol: str, pos_info: dict):

--- a/utils/liveTrading.py
+++ b/utils/liveTrading.py
@@ -24,6 +24,10 @@ _daily_trades: list[dict] = []
 _daily_start_balance: float | None = None
 _last_loss_timestamp: float = 0.0
 
+# Active positions tracker for outcome monitoring
+# key=symbol, value={'side','entry','tp','sl','strategy','timeframe','opened_at'}
+_tracked_positions: dict[str, dict] = {}
+
 
 def get_authenticated_exchange():
     """Return a Phemex exchange instance with trading credentials."""
@@ -95,6 +99,26 @@ def record_loss():
     """Mark a loss event to trigger cooldown."""
     global _last_loss_timestamp
     _last_loss_timestamp = time.time()
+
+
+def track_position(symbol: str, side: str, entry: float, tp: float, sl: float,
+                   strategy: str = "trend", timeframe: str = "15m"):
+    """Register an opened position for outcome monitoring."""
+    _tracked_positions[symbol] = {
+        'side': side,
+        'entry': entry,
+        'tp': tp,
+        'sl': sl,
+        'strategy': strategy,
+        'timeframe': timeframe,
+        'opened_at': time.time(),
+    }
+    log_event(f"📌 Tracking position: {symbol} {side} entry={entry} TP={tp} SL={sl}")
+
+
+def untrack_position(symbol: str):
+    """Remove a position from outcome monitoring (manual close, emergency, etc.)."""
+    _tracked_positions.pop(symbol, None)
 
 
 def check_capital_guards(exchange) -> tuple[bool, str | None]:
@@ -286,6 +310,9 @@ def execute_trade(symbol, side, entry_price, tp_price, sl_price, strategy_type="
 
         # TP is nice-to-have but not critical
         _place_tp_order(exchange, symbol, side, contracts, tp_price)
+
+        # Track position for outcome monitoring
+        track_position(symbol, side, entry_price, tp_price, sl_price, strategy_type)
 
         return {'success': True, 'order_id': order_id, 'contracts': contracts}
 
@@ -488,6 +515,7 @@ def close_position(symbol, reason="manual"):
             record_loss()
             log_event(f"Loss recorded for {symbol}: {pnl:.2f} USDT — cooldown active")
 
+        untrack_position(symbol)
         log_event(f"Position closed for {symbol} (reason: {reason}): {order.get('id')} PnL: {pnl:+.2f}")
         return {'success': True, 'order_id': order.get('id'), 'pnl': pnl}
 
@@ -550,3 +578,102 @@ def get_protection_status():
         'cooldown_remaining_sec': max(0, int(config.LIVE_TRADING_COOLDOWN_AFTER_LOSS_SEC - since_loss)) if cooldown_active else 0,
         'starting_balance': _daily_start_balance,
     }
+
+
+def monitor_trade_outcomes():
+    """
+    Check tracked positions and send Telegram alerts when trades complete.
+    Called each cycle from the main loop. Detects TP hit, SL hit, or unknown close.
+    """
+    if not _tracked_positions:
+        return
+
+    try:
+        exchange = get_authenticated_exchange()
+        open_positions = get_open_positions(exchange)
+        open_symbols = {p.get('symbol') for p in open_positions}
+    except Exception as e:
+        log_event(f"Outcome monitor: cannot fetch positions: {e}")
+        return
+
+    closed_symbols = [sym for sym in list(_tracked_positions) if sym not in open_symbols]
+
+    for symbol in closed_symbols:
+        pos_info = _tracked_positions.pop(symbol)
+        _send_outcome_alert(exchange, symbol, pos_info)
+
+
+def _send_outcome_alert(exchange, symbol: str, pos_info: dict):
+    """Determine trade outcome and send Telegram notification."""
+    from utils.telegramUtils import send_telegram
+
+    side = pos_info['side']
+    entry = pos_info['entry']
+    tp = pos_info['tp']
+    sl = pos_info['sl']
+    strategy = pos_info.get('strategy', 'unknown')
+    timeframe = pos_info.get('timeframe', '?')
+    opened_at = pos_info.get('opened_at', 0)
+
+    # Try to get the last price to determine outcome
+    outcome = "CLOSED"
+    pnl_estimate = None
+    try:
+        ticker = exchange.fetch_ticker(symbol)
+        last_price = float(ticker.get('last', 0) or 0)
+
+        if side == 'buy':
+            tp_distance = abs(last_price - tp) if tp else float('inf')
+            sl_distance = abs(last_price - sl) if sl else float('inf')
+            pnl_estimate = ((last_price - entry) / entry) * 100
+        else:
+            tp_distance = abs(last_price - tp) if tp else float('inf')
+            sl_distance = abs(last_price - sl) if sl else float('inf')
+            pnl_estimate = ((entry - last_price) / entry) * 100
+
+        if tp and sl:
+            if tp_distance < sl_distance:
+                outcome = "TP HIT ✅"
+            else:
+                outcome = "SL HIT ❌"
+        elif pnl_estimate is not None:
+            outcome = "TP HIT ✅" if pnl_estimate > 0 else "SL HIT ❌"
+    except Exception:
+        pass
+
+    # Calculate duration
+    duration_sec = int(time.time() - opened_at) if opened_at else 0
+    if duration_sec >= 3600:
+        duration_str = f"{duration_sec // 3600}h {(duration_sec % 3600) // 60}m"
+    elif duration_sec >= 60:
+        duration_str = f"{duration_sec // 60}m"
+    else:
+        duration_str = f"{duration_sec}s"
+
+    # Record PnL in daily tracking
+    if pnl_estimate is not None and pnl_estimate < 0:
+        record_loss()
+
+    emoji = "🎯" if "TP" in outcome else "🛑" if "SL" in outcome else "📊"
+
+    msg = (
+        f"{emoji} <b>Trade {outcome}</b>\n"
+        f"\n"
+        f"<b>Pair:</b> {symbol}\n"
+        f"<b>Side:</b> {side.upper()}\n"
+        f"<b>Strategy:</b> {strategy} ({timeframe})\n"
+        f"\n"
+        f"<b>Entry:</b> {entry}\n"
+        f"<b>TP:</b> {tp}\n"
+        f"<b>SL:</b> {sl}\n"
+    )
+
+    if pnl_estimate is not None:
+        msg += f"<b>Est. P&L:</b> {pnl_estimate:+.2f}%\n"
+
+    msg += f"<b>Duration:</b> {duration_str}\n"
+
+    try:
+        send_telegram(msg, parse_mode="HTML", bypass_rate_limit=True)
+    except Exception as e:
+        log_event(f"Failed to send outcome alert for {symbol}: {e}")

--- a/utils/telegramUtils.py
+++ b/utils/telegramUtils.py
@@ -198,6 +198,30 @@ def _cmd_live(args=None):
     return "Use <code>/live</code>, <code>/live on</code>, or <code>/live off</code>"
 
 
+def _cmd_alerts(args=None):
+    """Toggle trade outcome alerts (Telegram notifications when TP/SL hit)."""
+    args = args or []
+    if not args:
+        state = "ON ✅" if config.TRADE_OUTCOME_ALERTS_ENABLED else "OFF ❌"
+        return (
+            f"<b>🔔 Trade Outcome Alerts</b>\n"
+            f"Status: <b>{state}</b>\n\n"
+            f"When enabled, you'll receive a Telegram message\n"
+            f"every time a trade hits its TP or SL.\n\n"
+            f"<code>/alerts on</code> — enable notifications\n"
+            f"<code>/alerts off</code> — disable notifications"
+        )
+
+    sub = (args[0] or "").strip().lower()
+    if sub in ("on", "enable", "true", "1", "yes"):
+        config.TRADE_OUTCOME_ALERTS_ENABLED = True
+        return "🔔 Trade outcome alerts <b>ENABLED</b>. You'll be notified when trades hit TP or SL."
+    if sub in ("off", "disable", "false", "0", "no"):
+        config.TRADE_OUTCOME_ALERTS_ENABLED = False
+        return "🔕 Trade outcome alerts <b>DISABLED</b>. Trades will close silently."
+    return "Use <code>/alerts</code>, <code>/alerts on</code>, or <code>/alerts off</code>"
+
+
 def _cmd_positions():
     """Show open Phemex positions."""
     if not config.LIVE_TRADING_ENABLED:
@@ -546,7 +570,8 @@ HELP_TEXT = (
     "/live — View/toggle live trading on Phemex\n"
     "/positions — Open positions & account balance\n"
     "/guards — Capital protection status & limits\n"
-    "/close — Close a position (ex: /close ADA)\n\n"
+    "/close — Close a position (ex: /close ADA)\n"
+    "/alerts — Toggle trade outcome notifications (TP/SL hit)\n\n"
     "/help — This message\n\n"
     f"{LEGAL_DISCLAIMER}"
 )
@@ -605,6 +630,9 @@ def handle_telegram_command(text):
 
     if cmd in {"/close", "close"}:
         return _cmd_close(args), "HTML"
+
+    if cmd in {"/alerts", "alerts"}:
+        return _cmd_alerts(args), "HTML"
 
     handler = COMMAND_MAP.get(cmd)
     if handler:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds automatic Telegram notifications when a live trade reaches its conclusion (TP or SL hit), with a toggle to turn them on/off.

### How it works

1. When the bot executes a trade via `execute_trade()`, it registers the position in a tracker (symbol, side, entry, TP, SL, strategy, timeframe, timestamp)
2. Each main loop cycle, `monitor_trade_outcomes()` checks tracked positions against the exchange's open positions
3. When a tracked position disappears (closed on exchange), determines the outcome:
   - Compares last traded price proximity to TP vs SL levels
   - Labels as "TP HIT" or "SL HIT" accordingly
4. Sends a detailed Telegram alert with the result (if alerts enabled)

### Telegram commands

| Command | Action |
|---------|--------|
| `/alerts` | Show current alert status (on/off) |
| `/alerts on` | Enable TP/SL notifications (default) |
| `/alerts off` | Disable notifications — trades close silently |

### Alert format

```
🎯 Trade TP HIT ✅

Pair: SUI/USDT:USDT
Side: BUY
Strategy: trend (15m)

Entry: 1.50
TP: 1.60
SL: 1.45
Est. P&L: +6.67%
Duration: 2h 15m
```

### Files changed

- `config.py` — Added `TRADE_OUTCOME_ALERTS_ENABLED = True`
- `utils/liveTrading.py` — Added `track_position()`, `untrack_position()`, `monitor_trade_outcomes()`, `_send_outcome_alert()`; outcome monitor respects the config flag
- `utils/telegramUtils.py` — Added `/alerts` command handler + help text entry
- `bot.py` — Wired `monitor_trade_outcomes()` into main loop alongside watchdog
- `tests/test_outcome_monitor.py` — 13 tests covering tracking, outcome detection, alert toggling

**118 tests passing.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00058-e6aa-7a35-91d8-398c860a7bce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00058-e6aa-7a35-91d8-398c860a7bce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

