### PR TITLE
docs: standalone business portfolio extract (ready to move to new repo)

### DIFF
--- a/PORTFOLIO_STANDALONE.md
+++ b/PORTFOLIO_STANDALONE.md
@@ -1,0 +1,38 @@
+# Business portfolio — standalone extract
+
+The portfolio site lives on orphan branch:
+
+**`cursor/business-portfolio-standalone-d97d`**
+
+Clone it alone:
+
+```bash
+git clone --single-branch --branch cursor/business-portfolio-standalone-d97d \
+  https://github.com/battenadam04/crypto_ma_bot.git business-portfolio
+cd business-portfolio
+npm install
+cp .env.example .env
+npm run db:setup
+npm run dev
+```
+
+## Move to a new GitHub repository
+
+The Cursor GitHub App for this agent can only write to `crypto_ma_bot` and cannot create repos.
+
+1. Create an empty public repo (e.g. `business-portfolio`) with **no** README/license.
+2. Grant the Cursor GitHub App access to that repo.
+3. Reply in the agent chat with the new repo URL so it can push `main`.
+
+Or push yourself:
+
+```bash
+cd business-portfolio
+gh repo create battenadam04/business-portfolio --public --source=. --remote=origin --push
+```
+
+## Do not merge
+
+Do **not** merge `cursor/business-portfolio-standalone-d97d` (or this notes branch) into `master` — that would replace the trading bot with the website.
+
+Previous mixed history PR: #8 (`cursor/portfolio-site-f7bf`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Portfolio move helper (do not merge unless you want the notes file)

The **business portfolio site** is ready as a clean orphan branch (no trading-bot history):

**Branch:** [`cursor/business-portfolio-standalone-d97d`](https://github.com/battenadam04/crypto_ma_bot/tree/cursor/business-portfolio-standalone-d97d)

### Verified
- 15/15 Vitest unit tests passing
- 73/73 Playwright E2E tests passing (pages, forms, APIs, SEO, accessibility)
- Production build succeeds
- Self-contained SQLite (no third-party DB); unused auth/SEO packages removed

### Blocker: new GitHub repo
This agent’s GitHub App can only access `crypto_ma_bot` and **cannot create** a new repository. To finish the move:

1. Create an empty public repo (e.g. `business-portfolio`) — no README/license
2. Grant the **Cursor** GitHub App access to that repo
3. Reply with the new repo URL — the agent will push this extract as `main`

Or run locally:
```bash
git clone --single-branch --branch cursor/business-portfolio-standalone-d97d \
  https://github.com/battenadam04/crypto_ma_bot.git business-portfolio
cd business-portfolio
gh repo create battenadam04/business-portfolio --public --source=. --remote=origin --push
```

See `PORTFOLIO_STANDALONE.md` in this PR for the same instructions.

**Do not merge** `cursor/business-portfolio-standalone-d97d` into `master` (it would replace the bot). Prior mixed PR: #8.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89d9ab7-0928-41f7-ad5e-f6922c8ad97d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89d9ab7-0928-41f7-ad5e-f6922c8ad97d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

