### PR TITLE
Fix: harden title contrast on light backgrounds

### DIFF
--- a/src/app/about/AboutContent.tsx
+++ b/src/app/about/AboutContent.tsx
@@ -109,7 +109,7 @@ export default function AboutContent() {
       <section className="bg-gradient-to-b from-brand-50 to-surface-0 py-20">
         <div className="mx-auto max-w-7xl px-6">
           <div className="mx-auto max-w-3xl text-center">
-            <h1 className="text-4xl font-bold tracking-tight text-surface-900 sm:text-5xl">
+            <h1 className="text-4xl font-bold tracking-tight text-surface-950 sm:text-5xl">
               About{" "}
               <span className="bg-gradient-to-r from-brand-600 to-accent-500 bg-clip-text text-transparent">
                 Adam Batten
@@ -149,10 +149,10 @@ export default function AboutContent() {
                 <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-brand-100 text-brand-700">
                   {v.icon}
                 </div>
-                <h3 className="text-lg font-semibold text-surface-900">
+                <h3 className="text-lg font-semibold text-surface-950">
                   {v.title}
                 </h3>
-                <p className="mt-2 text-sm text-surface-600 leading-relaxed">
+                <p className="mt-2 text-sm text-surface-700 leading-relaxed">
                   {v.description}
                 </p>
               </motion.div>
@@ -188,10 +188,10 @@ export default function AboutContent() {
                     {step.step}
                   </div>
                   <div className="pt-2">
-                    <h3 className="text-xl font-semibold text-surface-900">
+                    <h3 className="text-xl font-semibold text-surface-950">
                       {step.title}
                     </h3>
-                    <p className="mt-2 text-surface-500 leading-relaxed max-w-lg">
+                    <p className="mt-2 text-surface-700 leading-relaxed max-w-lg">
                       {step.description}
                     </p>
                   </div>
@@ -222,7 +222,7 @@ export default function AboutContent() {
                 key={tech}
                 variants={item}
                 whileHover={{ scale: 1.05 }}
-                className="rounded-xl bg-surface-0 border border-surface-200 px-6 py-3 text-sm font-medium text-surface-700 shadow-sm hover:shadow-md hover:border-brand-200 transition-all"
+                className="rounded-xl bg-surface-0 border border-surface-200 px-6 py-3 text-sm font-semibold text-surface-950 shadow-sm hover:shadow-md hover:border-brand-200 transition-all"
               >
                 {tech}
               </motion.div>
@@ -233,10 +233,10 @@ export default function AboutContent() {
 
       <section className="py-20 bg-gradient-to-b from-surface-0 to-surface-50">
         <div className="mx-auto max-w-3xl px-6 text-center">
-          <h2 className="text-3xl font-bold text-surface-900 sm:text-4xl">
+          <h2 className="text-3xl font-bold text-surface-950 sm:text-4xl">
             Ready to start your project?
           </h2>
-          <p className="mt-4 text-lg text-surface-500">
+          <p className="mt-4 text-lg text-surface-700">
             Let&apos;s discuss your ideas and turn them into reality.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/app/contact/ContactContent.tsx
+++ b/src/app/contact/ContactContent.tsx
@@ -45,7 +45,7 @@ export default function ContactContent() {
     <>
       <section className="bg-gradient-to-b from-brand-50 to-surface-0 py-20">
         <div className="mx-auto max-w-7xl px-6 text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-surface-900 sm:text-5xl">
+          <h1 className="text-4xl font-bold tracking-tight text-surface-950 sm:text-5xl">
             Get in{" "}
             <span className="bg-gradient-to-r from-brand-600 to-accent-500 bg-clip-text text-transparent">
               Touch
@@ -73,7 +73,7 @@ export default function ContactContent() {
                   <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-brand-100 text-brand-700">
                     {info.icon}
                   </div>
-                  <h3 className="font-semibold text-surface-900">
+                  <h3 className="font-semibold text-surface-950">
                     {info.title}
                   </h3>
                   {info.href ? (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -148,6 +148,23 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Light-page titles: near-black ink so headings stay readable on
+   white / surface-50 / brand-50 backgrounds even if a utility is missing. */
+h1,
+h2,
+h3 {
+  color: var(--surface-950);
+}
+
+h1.text-white,
+h2.text-white,
+h3.text-white,
+.text-white h1,
+.text-white h2,
+.text-white h3 {
+  color: #ffffff;
+}
+
 ::selection {
   background-color: var(--brand-200);
   color: var(--brand-900);

--- a/src/app/portfolio/PortfolioGrid.tsx
+++ b/src/app/portfolio/PortfolioGrid.tsx
@@ -87,7 +87,7 @@ export default function PortfolioGrid({ projects, tags }: PortfolioGridProps) {
                     </div>
                   </div>
 
-                  <h3 className="text-xl font-semibold text-surface-900">
+                  <h3 className="text-xl font-semibold text-surface-950">
                     {project.title}
                   </h3>
 

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -23,7 +23,7 @@ export default async function PortfolioPage() {
     <>
       <section className="bg-gradient-to-b from-brand-50 to-surface-0 py-20">
         <div className="mx-auto max-w-7xl px-6 text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-surface-900 sm:text-5xl">
+          <h1 className="text-4xl font-bold tracking-tight text-surface-950 sm:text-5xl">
             My{" "}
             <span className="bg-gradient-to-r from-brand-600 to-accent-500 bg-clip-text text-transparent">
               Portfolio

--- a/src/app/services/ServicesContent.tsx
+++ b/src/app/services/ServicesContent.tsx
@@ -52,7 +52,7 @@ export default function ServicesContent({ services }: ServicesContentProps) {
           <Badge variant="pop" className="mb-4">
             {FIRST_TIME_OFFER.discount}% off first project — {FIRST_TIME_OFFER.code}
           </Badge>
-          <h1 className="text-4xl font-bold tracking-tight text-surface-900 sm:text-5xl">
+          <h1 className="text-4xl font-bold tracking-tight text-surface-950 sm:text-5xl">
             My{" "}
             <span className="bg-gradient-to-r from-brand-600 to-accent-500 bg-clip-text text-transparent">
               Services
@@ -91,7 +91,7 @@ export default function ServicesContent({ services }: ServicesContentProps) {
                     <ServiceIcon name={service.icon} className="h-7 w-7" />
                   </div>
 
-                  <h3 className="text-xl font-semibold text-surface-900">
+                  <h3 className="text-xl font-semibold text-surface-950">
                     {service.title}
                   </h3>
 

--- a/src/components/forms/ServiceRequestForm.tsx
+++ b/src/components/forms/ServiceRequestForm.tsx
@@ -118,7 +118,7 @@ export default function ServiceRequestForm({
       )}
 
       <fieldset className="space-y-6">
-        <legend className="text-lg font-semibold text-surface-900 mb-2">
+        <legend className="text-lg font-semibold text-surface-950 mb-2">
           Your Details
         </legend>
         <div className="grid gap-6 sm:grid-cols-2">
@@ -161,7 +161,7 @@ export default function ServiceRequestForm({
       </fieldset>
 
       <fieldset className="space-y-6">
-        <legend className="text-lg font-semibold text-surface-900 mb-2">
+        <legend className="text-lg font-semibold text-surface-950 mb-2">
           Project Details
         </legend>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -11,7 +11,7 @@ export default function Footer() {
               <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-brand-500 to-accent-500 text-white font-bold text-lg" aria-hidden="true">
                 AB
               </div>
-              <span className="text-xl font-bold text-surface-900">
+              <span className="text-xl font-bold text-surface-950">
                 Adam <span className="text-brand-600">Batten</span>
               </span>
             </Link>
@@ -58,7 +58,7 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wider text-surface-900">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-surface-950">
               Navigation
             </h3>
             <ul className="mt-4 space-y-3">
@@ -76,7 +76,7 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wider text-surface-900">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-surface-950">
               Contact
             </h3>
             <div className="mt-4 space-y-4">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-brand-500 to-accent-500 text-white font-bold text-lg shadow-lg shadow-brand-500/25 group-hover:shadow-brand-500/40 transition-shadow" aria-hidden="true">
             AB
           </div>
-          <span className="text-xl font-bold text-surface-900">
+          <span className="text-xl font-bold text-surface-950">
             Adam <span className="text-brand-600">Batten</span>
           </span>
         </Link>

--- a/src/components/sections/FeaturedProjects.tsx
+++ b/src/components/sections/FeaturedProjects.tsx
@@ -59,7 +59,7 @@ export default function FeaturedProjects({ projects }: FeaturedProjectsProps) {
                     {project.title.charAt(0)}
                   </div>
                 </div>
-                <h3 className="text-lg font-semibold text-surface-900">
+                <h3 className="text-lg font-semibold text-surface-950">
                   {project.title}
                 </h3>
                 <p className="mt-2 flex-1 text-sm text-surface-500">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -77,7 +77,7 @@ export default function Hero() {
               </span>
             </motion.div>
 
-            <h1 className="text-4xl font-extrabold tracking-tight text-surface-900 sm:text-5xl lg:text-6xl xl:text-7xl">
+            <h1 className="text-4xl font-extrabold tracking-tight text-surface-950 sm:text-5xl lg:text-6xl xl:text-7xl">
               I Build{" "}
               <span className="bg-gradient-to-r from-brand-600 via-accent-500 to-pop-500 bg-clip-text text-transparent animate-gradient">
                 Digital Experiences
@@ -167,7 +167,7 @@ await project.launch(); 🚀`}</code>
                   </svg>
                 </div>
                 <div>
-                  <div className="text-sm font-semibold text-surface-900">Project Deployed</div>
+                  <div className="text-sm font-semibold text-surface-950">Project Deployed</div>
                   <div className="text-xs text-surface-400">Just now</div>
                 </div>
               </div>
@@ -185,7 +185,7 @@ await project.launch(); 🚀`}</code>
                   </svg>
                 </div>
                 <div>
-                  <div className="text-sm font-semibold text-surface-900">100/100</div>
+                  <div className="text-sm font-semibold text-surface-950">100/100</div>
                   <div className="text-xs text-surface-400">Lighthouse Score</div>
                 </div>
               </div>

--- a/src/components/sections/ServicesOverview.tsx
+++ b/src/components/sections/ServicesOverview.tsx
@@ -66,7 +66,7 @@ export default function ServicesOverview({ services }: ServicesOverviewProps) {
                 <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-brand-100 text-brand-700">
                   <ServiceIcon name={service.icon} className="h-6 w-6" />
                 </div>
-                <h3 className="text-lg font-semibold text-surface-900">
+                <h3 className="text-lg font-semibold text-surface-950">
                   {service.title}
                 </h3>
                 <p className="mt-2 text-sm text-surface-500 leading-relaxed">

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -75,7 +75,7 @@ export default function Testimonials({ testimonials }: TestimonialsProps) {
                       .join("")}
                   </div>
                   <div>
-                    <div className="text-sm font-semibold text-surface-900">
+                    <div className="text-sm font-semibold text-surface-950">
                       {t.name}
                     </div>
                     <div className="text-xs text-surface-400">

--- a/src/components/sections/WhyChooseUs.tsx
+++ b/src/components/sections/WhyChooseUs.tsx
@@ -106,10 +106,10 @@ export default function WhyChooseUs() {
                 {reason.icon}
               </div>
               <div>
-                <h3 className="font-semibold text-surface-900">
+                <h3 className="font-semibold text-surface-950">
                   {reason.title}
                 </h3>
-                <p className="mt-2 text-sm text-surface-500 leading-relaxed">
+                <p className="mt-2 text-sm text-surface-700 leading-relaxed">
                   {reason.description}
                 </p>
               </div>

--- a/src/components/ui/SectionHeading.tsx
+++ b/src/components/ui/SectionHeading.tsx
@@ -17,22 +17,23 @@ export default function SectionHeading({
 }: SectionHeadingProps) {
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
+      initial={{ y: 16 }}
+      whileInView={{ y: 0 }}
       viewport={{ once: true, margin: "-50px" }}
-      transition={{ duration: 0.5 }}
+      transition={{ duration: 0.45 }}
       className={`mb-12 ${centered ? "text-center" : ""}`}
     >
       {eyebrow && (
-        <span className="mb-3 inline-block rounded-full bg-brand-100 px-4 py-1.5 text-sm font-semibold text-brand-700">
+        <span className="mb-3 inline-block rounded-full bg-brand-100 px-4 py-1.5 text-sm font-semibold text-brand-800">
           {eyebrow}
         </span>
       )}
-      <h2 className="mt-2 text-3xl font-bold tracking-tight text-surface-900 sm:text-4xl lg:text-5xl">
+      {/* Explicit near-black: light section backgrounds need max title contrast */}
+      <h2 className="mt-2 text-3xl font-bold tracking-tight text-surface-950 sm:text-4xl lg:text-5xl">
         {title}
       </h2>
       {description && (
-        <p className="mt-4 text-lg text-surface-600 max-w-2xl mx-auto">
+        <p className="mt-4 text-lg text-surface-700 max-w-2xl mx-auto">
           {description}
         </p>
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Darkens all section/page titles on light backgrounds (`surface-0` / `surface-50` / brand washes) to near-black `surface-950`
- Strengthens **Technologies I Use** tech-pill labels (`font-semibold text-surface-950`)
- Stops Framer Motion opacity fades on `SectionHeading` so titles never look washed mid-scroll
- Adds a CSS fallback so `h1`/`h2`/`h3` default to near-black ink on light pages (white titles on the CTA gradient still override)

## Deploy note
Live site lives in `battenadam04/business-portfolio`. `cursor[bot]` cannot push there (403). Please merge this commit onto `business-portfolio` `main` (or grant App write access / run a Cloud Agent on that repo) so Vercel picks it up.

```bash
# From a clone of business-portfolio:
git fetch https://github.com/battenadam04/crypto_ma_bot.git cursor/title-contrast-light-bg-d97d
git cherry-pick 6b1b908
git push origin main
```

## Test plan
- [ ] About → “Technologies I Use” title + tech chips clearly readable
- [ ] Spot-check Home / Services / Portfolio / Contact headings on white and pale gray
- [ ] CTA gradient heading stays white

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89d9ab7-0928-41f7-ad5e-f6922c8ad97d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89d9ab7-0928-41f7-ad5e-f6922c8ad97d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

