### PR TITLE
Feat: client portal with OTP login, chat, and progress tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
 DATABASE_URL="file:./prisma/dev.db"
 NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 
-# Contact form email (Resend) — required in production so messages reach you
+# Contact form + portal PIN emails (Resend)
 # 1. Sign up at https://resend.com with adambatten@live.co.uk
 # 2. Create an API key → paste below
 # 3. Add the same vars in Vercel → Project → Settings → Environment Variables
 RESEND_API_KEY=""
 CONTACT_TO_EMAIL="adambatten@live.co.uk"
+# Admin portal login (defaults to CONTACT_TO_EMAIL if omitted)
+ADMIN_EMAIL="adambatten@live.co.uk"
 # Optional: after verifying a domain in Resend, set e.g. "Adam Batten <hello@yourdomain.com>"
 # CONTACT_FROM_EMAIL="Adam Batten Portfolio <onboarding@resend.dev>"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ CONTACT_FROM_EMAIL="Adam Batten <hello@yourdomain.com>"
 
 Without `RESEND_API_KEY`, submissions still save to the local SQLite DB (useful for tests/dev). On Vercel, set the API key so you actually receive the emails.
 
+## Client portal (OTP)
+
+After work begins, create a **portal** for the client (signed in as admin). Clients open `/portal`, enter their email, and receive a **6-digit PIN** (no passwords). “Forgot PIN” simply emails a new code.
+
+- **Client:** chat + live progress milestones (read-only tracking)
+- **Admin** (`ADMIN_EMAIL` / `adambatten@live.co.uk`): same screen, plus controls to update milestones, project status, and summary; create portals from `/portal/home`
+
+Locally without Resend, the PIN is returned as `devCode` in the API response and printed in the server log. Seed includes a demo client: `client@example.com`.
+
 ## Testing
 
 ```bash

--- a/e2e/portal.spec.ts
+++ b/e2e/portal.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Client portal OTP", () => {
+  test("shows portal login", async ({ page }) => {
+    await page.goto("/portal");
+    await expect(page.getByRole("heading", { name: "Client portal" })).toBeVisible();
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Email me a PIN" })).toBeVisible();
+  });
+
+  test("demo client can request PIN and open workspace", async ({ page }) => {
+    await page.goto("/portal");
+    await page.getByLabel("Email").fill("client@example.com");
+    await page.getByRole("button", { name: "Email me a PIN" }).click();
+
+    await expect(page.getByLabel("6-digit PIN")).toBeVisible({ timeout: 10000 });
+    const devHint = page.getByText(/Dev mode/);
+    await expect(devHint).toBeVisible();
+    const text = await devHint.textContent();
+    const pin = text?.match(/\b(\d{6})\b/)?.[1];
+    expect(pin).toBeTruthy();
+
+    await page.getByLabel("6-digit PIN").fill(pin!);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page).toHaveURL(/\/portal\/home/, { timeout: 10000 });
+    await expect(page.getByText("Demo — SEO Landing Page")).toBeVisible();
+
+    await page.getByRole("link", { name: /Demo — SEO Landing Page/ }).click();
+    await expect(page.getByRole("heading", { name: "Messages" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
+    await expect(page.getByText("Forgot PIN / send a new one")).toHaveCount(0);
+  });
+
+  test("forgot PIN control is available after requesting a code", async ({
+    page,
+  }) => {
+    await page.goto("/portal");
+    await page.getByLabel("Email").fill("client@example.com");
+    await page.getByRole("button", { name: "Email me a PIN" }).click();
+    await expect(
+      page.getByRole("button", { name: "Forgot PIN / send a new one" }),
+    ).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,5 +23,9 @@ export default defineConfig({
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 180000,
+    env: {
+      ...process.env,
+      PORTAL_DEV_OTP: "1",
+    },
   },
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,3 +77,67 @@ model Testimonial {
   featured  Boolean  @default(false)
   createdAt DateTime @default(now())
 }
+
+/// Active client engagement — OTP login grants access to chat + progress.
+model ClientPortal {
+  id          String   @id @default(uuid())
+  title       String
+  clientName  String
+  clientEmail String
+  status      String   @default("active") // active | paused | completed
+  summary     String   @default("")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  milestones  PortalMilestone[]
+  messages    PortalMessage[]
+
+  @@index([clientEmail])
+}
+
+model PortalMilestone {
+  id          String   @id @default(uuid())
+  portalId    String
+  portal      ClientPortal @relation(fields: [portalId], references: [id], onDelete: Cascade)
+  title       String
+  description String   @default("")
+  status      String   @default("pending") // pending | in_progress | done
+  order       Int      @default(0)
+  updatedAt   DateTime @updatedAt
+  createdAt   DateTime @default(now())
+
+  @@index([portalId])
+}
+
+model PortalMessage {
+  id         String   @id @default(uuid())
+  portalId   String
+  portal     ClientPortal @relation(fields: [portalId], references: [id], onDelete: Cascade)
+  senderRole String   // client | admin
+  senderName String
+  body       String
+  createdAt  DateTime @default(now())
+
+  @@index([portalId])
+}
+
+model PortalOtp {
+  id        String   @id @default(uuid())
+  email     String
+  codeHash  String
+  attempts  Int      @default(0)
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@index([email])
+}
+
+model PortalSession {
+  id        String   @id @default(uuid())
+  tokenHash String   @unique
+  email     String
+  isAdmin   Boolean  @default(false)
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@index([email])
+}

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -223,5 +223,54 @@ for (const row of obsolete) {
 }
 
 testimonials.forEach(insertTestimonial);
+
+// Demo client portal (OTP login uses this email in local/dev)
+const demoEmail = "client@example.com";
+const existingPortal = db
+  .prepare("SELECT id FROM ClientPortal WHERE clientEmail = ?")
+  .get(demoEmail);
+
+if (!existingPortal) {
+  const portalId = randomUUID();
+  db.prepare(
+    `INSERT INTO ClientPortal (id, title, clientName, clientEmail, status, summary, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+  ).run(
+    portalId,
+    "Demo — SEO Landing Page",
+    "Alex Client",
+    demoEmail,
+    "active",
+    "Welcome! This is a sample portal so you can try chat and progress tracking.",
+  );
+
+  const milestones = [
+    ["Kick-off & requirements", "Align on goals and scope", "done", 0],
+    ["Design / structure", "Layout and content plan", "done", 1],
+    ["Build in progress", "Implementation", "in_progress", 2],
+    ["Review & revisions", "Your feedback round", "pending", 3],
+    ["Launch & handover", "Go live and hand over", "pending", 4],
+  ];
+
+  const insertMilestone = db.prepare(
+    `INSERT INTO PortalMilestone (id, portalId, title, description, status, "order", createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+  );
+  for (const [title, description, status, order] of milestones) {
+    insertMilestone.run(randomUUID(), portalId, title, description, status, order);
+  }
+
+  db.prepare(
+    `INSERT INTO PortalMessage (id, portalId, senderRole, senderName, body, createdAt)
+     VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+  ).run(
+    randomUUID(),
+    portalId,
+    "admin",
+    "Adam Batten",
+    "Hi Alex — portal is ready. Drop questions here anytime and watch the milestones update as we go.",
+  );
+}
+
 console.log("Seeding complete.");
 db.close();

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -19,13 +19,14 @@ describe("SITE_CONFIG", () => {
 
 describe("NAV_LINKS", () => {
   it("contains expected navigation items", () => {
-    expect(NAV_LINKS.length).toBe(5);
+    expect(NAV_LINKS.length).toBe(6);
     const labels = NAV_LINKS.map((l) => l.label);
     expect(labels).toContain("Home");
     expect(labels).toContain("Portfolio");
     expect(labels).toContain("Services");
     expect(labels).toContain("About");
     expect(labels).toContain("Contact");
+    expect(labels).toContain("Portal");
   });
 
   it("all links have href starting with /", () => {

--- a/src/__tests__/portal.test.ts
+++ b/src/__tests__/portal.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  portalOtpRequestSchema,
+  portalOtpVerifySchema,
+  portalCreateSchema,
+  portalMessageSchema,
+} from "@/lib/portal-validations";
+
+describe("portal validations", () => {
+  it("accepts a valid OTP request email", () => {
+    expect(
+      portalOtpRequestSchema.safeParse({ email: "client@example.com" }).success,
+    ).toBe(true);
+  });
+
+  it("requires a 6-digit PIN", () => {
+    expect(
+      portalOtpVerifySchema.safeParse({
+        email: "client@example.com",
+        code: "12345",
+      }).success,
+    ).toBe(false);
+    expect(
+      portalOtpVerifySchema.safeParse({
+        email: "client@example.com",
+        code: "123456",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("validates portal creation fields", () => {
+    expect(
+      portalCreateSchema.safeParse({
+        title: "Landing page",
+        clientName: "Alex",
+        clientEmail: "alex@example.com",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects empty chat messages", () => {
+    expect(portalMessageSchema.safeParse({ body: "   " }).success).toBe(false);
+    expect(portalMessageSchema.safeParse({ body: "Hello" }).success).toBe(true);
+  });
+});

--- a/src/app/api/portal/logout/route.ts
+++ b/src/app/api/portal/logout/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import {
+  clearSessionCookie,
+  destroySession,
+  PORTAL_COOKIE,
+} from "@/lib/portal-auth";
+
+export async function POST() {
+  try {
+    const jar = await cookies();
+    const token = jar.get(PORTAL_COOKIE)?.value;
+    await destroySession(token);
+    await clearSessionCookie();
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/portal/otp/request/route.ts
+++ b/src/app/api/portal/otp/request/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendPortalOtpEmail, isEmailConfigured } from "@/lib/email";
+import {
+  createAndStoreOtp,
+  emailCanAccessPortal,
+  normalizeEmail,
+} from "@/lib/portal-auth";
+import { portalOtpRequestSchema } from "@/lib/portal-validations";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = portalOtpRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const email = normalizeEmail(parsed.data.email);
+    const allowed = await emailCanAccessPortal(email);
+
+    // Always return the same shape so emails are not enumerable.
+    if (!allowed) {
+      return NextResponse.json({
+        success: true,
+        message:
+          "If that email has portal access, a PIN is on its way. Check your inbox.",
+      });
+    }
+
+    const code = await createAndStoreOtp(email);
+    const allowDevCode =
+      process.env.NODE_ENV !== "production" ||
+      process.env.PORTAL_DEV_OTP === "1";
+
+    if (isEmailConfigured()) {
+      try {
+        await sendPortalOtpEmail({ to: email, code });
+      } catch (err) {
+        console.error("Portal OTP email failed:", err);
+        return NextResponse.json(
+          { error: "Could not send PIN email. Try again shortly." },
+          { status: 502 },
+        );
+      }
+    } else if (allowDevCode) {
+      console.info(`[portal-otp] ${email} → ${code}`);
+    } else {
+      return NextResponse.json(
+        { error: "Email delivery is not configured on the server." },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message:
+        "If that email has portal access, a PIN is on its way. Check your inbox.",
+      // Shown only when Resend is off and PORTAL_DEV_OTP / non-production
+      ...(allowDevCode && !isEmailConfigured() ? { devCode: code } : {}),
+    });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/portal/otp/verify/route.ts
+++ b/src/app/api/portal/otp/verify/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createSession,
+  normalizeEmail,
+  setSessionCookie,
+  verifyOtpCode,
+} from "@/lib/portal-auth";
+import { portalOtpVerifySchema } from "@/lib/portal-validations";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = portalOtpVerifySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const email = normalizeEmail(parsed.data.email);
+    const result = await verifyOtpCode(email, parsed.data.code);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 401 });
+    }
+
+    const token = await createSession(email);
+    await setSessionCookie(token);
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/portal/projects/[id]/messages/route.ts
+++ b/src/app/api/portal/projects/[id]/messages/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { assertPortalAccess, getPortalAuth } from "@/lib/portal-auth";
+import { portalMessageSchema } from "@/lib/portal-validations";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await context.params;
+    if (!(await assertPortalAccess(id, auth))) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const messages = await prisma.portalMessage.findMany({
+      where: { portalId: id },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return NextResponse.json({ messages });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await context.params;
+    if (!(await assertPortalAccess(id, auth))) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const parsed = portalMessageSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const portal = await prisma.clientPortal.findUnique({
+      where: { id },
+      select: { clientName: true },
+    });
+    if (!portal) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const message = await prisma.portalMessage.create({
+      data: {
+        portalId: id,
+        senderRole: auth.isAdmin ? "admin" : "client",
+        senderName: auth.isAdmin ? "Adam Batten" : portal.clientName,
+        body: parsed.data.body,
+      },
+    });
+
+    await prisma.clientPortal.update({
+      where: { id },
+      data: { updatedAt: new Date() },
+    });
+
+    return NextResponse.json({ success: true, message }, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/portal/projects/[id]/milestones/route.ts
+++ b/src/app/api/portal/projects/[id]/milestones/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getPortalAuth } from "@/lib/portal-auth";
+import {
+  portalMilestoneCreateSchema,
+  portalMilestoneUpdateSchema,
+} from "@/lib/portal-validations";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth?.isAdmin) {
+      return NextResponse.json({ error: "Admin only" }, { status: 403 });
+    }
+
+    const { id: portalId } = await context.params;
+    const body = await request.json();
+    const parsed = portalMilestoneCreateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const max = await prisma.portalMilestone.aggregate({
+      where: { portalId },
+      _max: { order: true },
+    });
+
+    const milestone = await prisma.portalMilestone.create({
+      data: {
+        portalId,
+        title: parsed.data.title,
+        description: parsed.data.description || "",
+        status: parsed.data.status || "pending",
+        order: (max._max.order ?? -1) + 1,
+      },
+    });
+
+    return NextResponse.json({ success: true, milestone }, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth?.isAdmin) {
+      return NextResponse.json({ error: "Admin only" }, { status: 403 });
+    }
+
+    const { id: portalId } = await context.params;
+    const body = await request.json();
+    const milestoneId = body?.id as string | undefined;
+    if (!milestoneId) {
+      return NextResponse.json(
+        { error: "Milestone id required" },
+        { status: 400 },
+      );
+    }
+
+    const parsed = portalMilestoneUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const existing = await prisma.portalMilestone.findFirst({
+      where: { id: milestoneId, portalId },
+    });
+    if (!existing) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const milestone = await prisma.portalMilestone.update({
+      where: { id: milestoneId },
+      data: {
+        title: parsed.data.title,
+        description: parsed.data.description,
+        status: parsed.data.status,
+        order: parsed.data.order,
+      },
+    });
+
+    await prisma.clientPortal.update({
+      where: { id: portalId },
+      data: { updatedAt: new Date() },
+    });
+
+    return NextResponse.json({ success: true, milestone });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth?.isAdmin) {
+      return NextResponse.json({ error: "Admin only" }, { status: 403 });
+    }
+
+    const { id: portalId } = await context.params;
+    const milestoneId = request.nextUrl.searchParams.get("milestoneId");
+    if (!milestoneId) {
+      return NextResponse.json(
+        { error: "milestoneId query required" },
+        { status: 400 },
+      );
+    }
+
+    const existing = await prisma.portalMilestone.findFirst({
+      where: { id: milestoneId, portalId },
+    });
+    if (!existing) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await prisma.portalMilestone.delete({ where: { id: milestoneId } });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/portal/projects/[id]/route.ts
+++ b/src/app/api/portal/projects/[id]/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { assertPortalAccess, getPortalAuth } from "@/lib/portal-auth";
+import { portalMetaUpdateSchema } from "@/lib/portal-validations";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await context.params;
+    const allowed = await assertPortalAccess(id, auth);
+    if (!allowed) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const portal = await prisma.clientPortal.findUnique({
+      where: { id },
+      include: {
+        milestones: { orderBy: { order: "asc" } },
+        messages: { orderBy: { createdAt: "asc" } },
+      },
+    });
+
+    if (!portal) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      auth: { email: auth.email, isAdmin: auth.isAdmin },
+      portal,
+    });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth?.isAdmin) {
+      return NextResponse.json({ error: "Admin only" }, { status: 403 });
+    }
+
+    const { id } = await context.params;
+    const body = await request.json();
+    const parsed = portalMetaUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const portal = await prisma.clientPortal.update({
+      where: { id },
+      data: parsed.data,
+      include: {
+        milestones: { orderBy: { order: "asc" } },
+        messages: { orderBy: { createdAt: "asc" } },
+      },
+    });
+
+    return NextResponse.json({ success: true, portal });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/portal/projects/route.ts
+++ b/src/app/api/portal/projects/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getPortalAuth, normalizeEmail } from "@/lib/portal-auth";
+import { portalCreateSchema } from "@/lib/portal-validations";
+
+const DEFAULT_MILESTONES = [
+  { title: "Kick-off & requirements", description: "Align on goals and scope" },
+  { title: "Design / structure", description: "Layout and content plan" },
+  { title: "Build in progress", description: "Implementation" },
+  { title: "Review & revisions", description: "Your feedback round" },
+  { title: "Launch & handover", description: "Go live and hand over" },
+];
+
+export async function GET() {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const portals = await prisma.clientPortal.findMany({
+      where: auth.isAdmin ? undefined : { clientEmail: auth.email },
+      orderBy: { updatedAt: "desc" },
+      include: {
+        milestones: { orderBy: { order: "asc" } },
+        _count: { select: { messages: true } },
+      },
+    });
+
+    return NextResponse.json({
+      auth: { email: auth.email, isAdmin: auth.isAdmin },
+      portals,
+    });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getPortalAuth();
+    if (!auth?.isAdmin) {
+      return NextResponse.json({ error: "Admin only" }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const parsed = portalCreateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const milestones =
+      parsed.data.milestones && parsed.data.milestones.length > 0
+        ? parsed.data.milestones
+        : DEFAULT_MILESTONES;
+
+    const portal = await prisma.clientPortal.create({
+      data: {
+        title: parsed.data.title,
+        clientName: parsed.data.clientName,
+        clientEmail: normalizeEmail(parsed.data.clientEmail),
+        summary: parsed.data.summary || "",
+        milestones: {
+          create: milestones.map((m, i) => ({
+            title: m.title,
+            description: m.description || "",
+            order: i,
+            status: i === 0 ? "in_progress" : "pending",
+          })),
+        },
+      },
+      include: { milestones: { orderBy: { order: "asc" } } },
+    });
+
+    return NextResponse.json({ success: true, portal }, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/service-requests/route.ts
+++ b/src/app/api/service-requests/route.ts
@@ -39,8 +39,8 @@ export async function POST(request: NextRequest) {
           email: parsed.data.email,
           company: parsed.data.company,
           serviceTitle: service.title,
-          budget: parsed.data.budget,
-          timeline: parsed.data.timeline,
+          budget: parsed.data.budget || "—",
+          timeline: parsed.data.timeline || "—",
           description: parsed.data.description,
         });
         emailId = sent.id;

--- a/src/app/portal/[id]/page.tsx
+++ b/src/app/portal/[id]/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import PortalWorkspace from "@/components/portal/PortalWorkspace";
+import { prisma } from "@/lib/db";
+import { assertPortalAccess, getPortalAuth } from "@/lib/portal-auth";
+
+export const metadata: Metadata = {
+  title: "Project portal",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+type PageProps = { params: Promise<{ id: string }> };
+
+export default async function PortalProjectPage({ params }: PageProps) {
+  const auth = await getPortalAuth();
+  if (!auth) redirect("/portal");
+
+  const { id } = await params;
+  if (!(await assertPortalAccess(id, auth))) {
+    redirect("/portal/home");
+  }
+
+  const portal = await prisma.clientPortal.findUnique({
+    where: { id },
+    include: {
+      milestones: { orderBy: { order: "asc" } },
+      messages: { orderBy: { createdAt: "asc" } },
+    },
+  });
+
+  if (!portal) notFound();
+
+  return (
+    <section className="bg-surface-50 min-h-[70vh]">
+      <PortalWorkspace
+        isAdmin={auth.isAdmin}
+        portal={{
+          ...portal,
+          milestones: portal.milestones.map((m) => ({
+            ...m,
+          })),
+          messages: portal.messages.map((m) => ({
+            ...m,
+            createdAt: m.createdAt.toISOString(),
+          })),
+        }}
+      />
+    </section>
+  );
+}

--- a/src/app/portal/home/page.tsx
+++ b/src/app/portal/home/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import PortalHomeClient from "@/components/portal/PortalHomeClient";
+import { prisma } from "@/lib/db";
+import { getPortalAuth } from "@/lib/portal-auth";
+
+export const metadata: Metadata = {
+  title: "Portal projects",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function PortalHomePage() {
+  const auth = await getPortalAuth();
+  if (!auth) redirect("/portal");
+
+  const portals = await prisma.clientPortal.findMany({
+    where: auth.isAdmin ? undefined : { clientEmail: auth.email },
+    orderBy: { updatedAt: "desc" },
+    include: {
+      milestones: { select: { status: true } },
+      _count: { select: { messages: true } },
+    },
+  });
+
+  return (
+    <section className="bg-surface-0 min-h-[70vh]">
+      <PortalHomeClient
+        email={auth.email}
+        isAdmin={auth.isAdmin}
+        portals={portals.map((p) => ({
+          ...p,
+          updatedAt: p.updatedAt.toISOString(),
+        }))}
+      />
+    </section>
+  );
+}

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import PortalLoginForm from "@/components/portal/PortalLoginForm";
+import { getPortalAuth } from "@/lib/portal-auth";
+
+export const metadata: Metadata = {
+  title: "Client portal",
+  description:
+    "Sign in with a one-time PIN to chat about your project and track progress.",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function PortalLoginPage() {
+  const auth = await getPortalAuth();
+  if (auth) redirect("/portal/home");
+
+  return (
+    <section className="bg-gradient-to-b from-brand-50 to-surface-0 py-16">
+      <div className="mx-auto max-w-7xl px-6">
+        <PortalLoginForm />
+      </div>
+    </section>
+  );
+}

--- a/src/components/portal/PortalChat.tsx
+++ b/src/components/portal/PortalChat.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Button from "@/components/ui/Button";
+import Textarea from "@/components/ui/Textarea";
+
+export type PortalMessage = {
+  id: string;
+  senderRole: string;
+  senderName: string;
+  body: string;
+  createdAt: string;
+};
+
+interface PortalChatProps {
+  portalId: string;
+  initialMessages: PortalMessage[];
+  isAdmin: boolean;
+}
+
+export default function PortalChat({
+  portalId,
+  initialMessages,
+  isAdmin,
+}: PortalChatProps) {
+  const [messages, setMessages] = useState(initialMessages);
+  const [body, setBody] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length]);
+
+  useEffect(() => {
+    const timer = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/portal/projects/${portalId}/messages`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setMessages(data.messages);
+      } catch {
+        /* ignore poll errors */
+      }
+    }, 8000);
+    return () => clearInterval(timer);
+  }, [portalId]);
+
+  const send = async () => {
+    if (!body.trim()) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/portal/projects/${portalId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Could not send");
+      setMessages((prev) => [...prev, data.message]);
+      setBody("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not send");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-[28rem] flex-col rounded-2xl border border-surface-200 bg-surface-0">
+      <div className="border-b border-surface-200 px-5 py-4">
+        <h2 className="text-lg font-semibold text-surface-950">Messages</h2>
+        <p className="text-sm text-surface-700">
+          {isAdmin
+            ? "Chat with your client about this project."
+            : "Chat with Adam about your project."}
+        </p>
+      </div>
+
+      <div className="flex-1 space-y-3 overflow-y-auto px-5 py-4">
+        {messages.length === 0 && (
+          <p className="text-sm text-surface-600">No messages yet — say hello.</p>
+        )}
+        {messages.map((m) => {
+          const mine =
+            (isAdmin && m.senderRole === "admin") ||
+            (!isAdmin && m.senderRole === "client");
+          return (
+            <div
+              key={m.id}
+              className={`flex ${mine ? "justify-end" : "justify-start"}`}
+            >
+              <div
+                className={`max-w-[85%] rounded-2xl px-4 py-3 text-sm ${
+                  mine
+                    ? "bg-brand-600 text-white"
+                    : "bg-surface-100 text-surface-950"
+                }`}
+              >
+                <div
+                  className={`mb-1 text-xs font-semibold ${
+                    mine ? "text-white/80" : "text-surface-600"
+                  }`}
+                >
+                  {m.senderName}
+                </div>
+                <p className="whitespace-pre-wrap">{m.body}</p>
+                <div
+                  className={`mt-1 text-[11px] ${
+                    mine ? "text-white/70" : "text-surface-500"
+                  }`}
+                >
+                  {new Date(m.createdAt).toLocaleString()}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="border-t border-surface-200 p-4 space-y-3">
+        <Textarea
+          id={`chat-${portalId}`}
+          label="Write a message"
+          rows={3}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Ask a question or share an update…"
+        />
+        {error && (
+          <p className="text-sm text-error-600" role="alert">
+            {error}
+          </p>
+        )}
+        <Button
+          type="button"
+          variant="primary"
+          loading={loading}
+          onClick={() => void send()}
+        >
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/PortalHomeClient.tsx
+++ b/src/components/portal/PortalHomeClient.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+type PortalListItem = {
+  id: string;
+  title: string;
+  clientName: string;
+  clientEmail: string;
+  status: string;
+  updatedAt: string;
+  milestones: { status: string }[];
+  _count: { messages: number };
+};
+
+interface PortalHomeClientProps {
+  email: string;
+  isAdmin: boolean;
+  portals: PortalListItem[];
+}
+
+export default function PortalHomeClient({
+  email,
+  isAdmin,
+  portals: initial,
+}: PortalHomeClientProps) {
+  const router = useRouter();
+  const [portals, setPortals] = useState(initial);
+  const [showCreate, setShowCreate] = useState(false);
+  const [title, setTitle] = useState("");
+  const [clientName, setClientName] = useState("");
+  const [clientEmail, setClientEmail] = useState("");
+  const [summary, setSummary] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const logout = async () => {
+    await fetch("/api/portal/logout", { method: "POST" });
+    router.push("/portal");
+    router.refresh();
+  };
+
+  const create = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/portal/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, clientName, clientEmail, summary }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Could not create");
+      setPortals((prev) => [
+        {
+          ...data.portal,
+          _count: { messages: 0 },
+        },
+        ...prev,
+      ]);
+      setShowCreate(false);
+      setTitle("");
+      setClientName("");
+      setClientEmail("");
+      setSummary("");
+      router.push(`/portal/${data.portal.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not create");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 px-6 py-12">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-surface-950">
+            {isAdmin ? "Your client portals" : "Your projects"}
+          </h1>
+          <p className="mt-2 text-surface-700">
+            Signed in as <strong>{email}</strong>
+            {isAdmin ? " (admin)" : ""}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {isAdmin && (
+            <Button
+              type="button"
+              variant="primary"
+              onClick={() => setShowCreate((v) => !v)}
+            >
+              {showCreate ? "Cancel" : "New portal"}
+            </Button>
+          )}
+          <Button type="button" variant="ghost" onClick={() => void logout()}>
+            Sign out
+          </Button>
+        </div>
+      </div>
+
+      {showCreate && isAdmin && (
+        <div className="space-y-4 rounded-2xl border border-surface-200 bg-surface-0 p-6">
+          <h2 className="text-lg font-semibold text-surface-950">
+            Start a client portal
+          </h2>
+          <p className="text-sm text-surface-700">
+            The client signs in with their email + a PIN. Default milestones are
+            added automatically — you can edit them on the project page.
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Input
+              id="create-title"
+              label="Project title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Acme — SEO landing page"
+            />
+            <Input
+              id="create-client-name"
+              label="Client name"
+              value={clientName}
+              onChange={(e) => setClientName(e.target.value)}
+            />
+            <Input
+              id="create-client-email"
+              label="Client email"
+              type="email"
+              value={clientEmail}
+              onChange={(e) => setClientEmail(e.target.value)}
+            />
+            <Input
+              id="create-summary"
+              label="Short summary (optional)"
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-error-600" role="alert">
+              {error}
+            </p>
+          )}
+          <Button
+            type="button"
+            variant="primary"
+            loading={loading}
+            onClick={() => void create()}
+          >
+            Create portal
+          </Button>
+        </div>
+      )}
+
+      {portals.length === 0 ? (
+        <p className="rounded-2xl border border-dashed border-surface-300 bg-surface-50 px-6 py-12 text-center text-surface-700">
+          {isAdmin
+            ? "No portals yet. Create one when work begins."
+            : "No active projects linked to this email yet."}
+        </p>
+      ) : (
+        <ul className="grid gap-4">
+          {portals.map((p) => {
+            const done = p.milestones.filter((m) => m.status === "done").length;
+            const total = p.milestones.length;
+            return (
+              <li key={p.id}>
+                <Link
+                  href={`/portal/${p.id}`}
+                  className="block rounded-2xl border border-surface-200 bg-surface-0 p-5 transition hover:border-brand-300 hover:shadow-md"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h2 className="text-lg font-semibold text-surface-950">
+                      {p.title}
+                    </h2>
+                    <span className="rounded-full bg-surface-100 px-2.5 py-1 text-xs font-semibold capitalize text-surface-700">
+                      {p.status}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-surface-700">
+                    {isAdmin
+                      ? `${p.clientName} · ${p.clientEmail}`
+                      : "Open to chat and view progress"}
+                  </p>
+                  <p className="mt-3 text-xs text-surface-500">
+                    {done}/{total} milestones · {p._count.messages} messages ·
+                    updated {new Date(p.updatedAt).toLocaleDateString()}
+                  </p>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/portal/PortalLoginForm.tsx
+++ b/src/components/portal/PortalLoginForm.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+type Step = "email" | "pin";
+
+export default function PortalLoginForm() {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>("email");
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [message, setMessage] = useState("");
+  const [devCode, setDevCode] = useState<string | null>(null);
+
+  const requestPin = async () => {
+    setStatus("loading");
+    setMessage("");
+    setDevCode(null);
+    try {
+      const res = await fetch("/api/portal/otp/request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || "Could not send PIN");
+      if (body.devCode) setDevCode(body.devCode);
+      setMessage(body.message || "Check your email for a PIN.");
+      setStep("pin");
+      setStatus("idle");
+    } catch (err) {
+      setStatus("error");
+      setMessage(err instanceof Error ? err.message : "Something went wrong");
+    }
+  };
+
+  const verifyPin = async () => {
+    setStatus("loading");
+    setMessage("");
+    try {
+      const res = await fetch("/api/portal/otp/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, code }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || "Invalid PIN");
+      router.push("/portal/home");
+      router.refresh();
+    } catch (err) {
+      setStatus("error");
+      setMessage(err instanceof Error ? err.message : "Something went wrong");
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-md space-y-6 rounded-2xl border border-surface-200 bg-surface-0 p-8 shadow-sm">
+      <div>
+        <h1 className="text-2xl font-bold text-surface-950">Client portal</h1>
+        <p className="mt-2 text-sm text-surface-700">
+          No password needed. I&apos;ll email you a one-time PIN to sign in.
+        </p>
+      </div>
+
+      {step === "email" ? (
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void requestPin();
+          }}
+        >
+          <Input
+            id="portal-email"
+            label="Email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            required
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            size="lg"
+            className="w-full"
+            loading={status === "loading"}
+          >
+            Email me a PIN
+          </Button>
+        </form>
+      ) : (
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void verifyPin();
+          }}
+        >
+          <p className="text-sm text-surface-700">
+            PIN sent to <strong className="text-surface-950">{email}</strong>
+          </p>
+          <Input
+            id="portal-pin"
+            label="6-digit PIN"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
+            placeholder="123456"
+            required
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            size="lg"
+            className="w-full"
+            loading={status === "loading"}
+          >
+            Sign in
+          </Button>
+          <div className="flex flex-wrap gap-3 text-sm">
+            <button
+              type="button"
+              className="font-medium text-brand-700 hover:underline"
+              onClick={() => {
+                void requestPin();
+              }}
+            >
+              Forgot PIN / send a new one
+            </button>
+            <button
+              type="button"
+              className="text-surface-600 hover:underline"
+              onClick={() => {
+                setStep("email");
+                setCode("");
+                setMessage("");
+                setDevCode(null);
+              }}
+            >
+              Use a different email
+            </button>
+          </div>
+        </form>
+      )}
+
+      {message && (
+        <p
+          className={`text-sm ${status === "error" ? "text-error-600" : "text-surface-700"}`}
+          role={status === "error" ? "alert" : "status"}
+        >
+          {message}
+        </p>
+      )}
+
+      {devCode && (
+        <p className="rounded-lg bg-surface-100 px-3 py-2 text-xs text-surface-700">
+          Dev mode (no Resend key): PIN is <strong>{devCode}</strong>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/portal/PortalProgress.tsx
+++ b/src/components/portal/PortalProgress.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+export type PortalMilestone = {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  order: number;
+};
+
+interface PortalProgressProps {
+  portalId: string;
+  initialMilestones: PortalMilestone[];
+  isAdmin: boolean;
+  portalStatus: string;
+  summary: string;
+  title: string;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: "Pending",
+  in_progress: "In progress",
+  done: "Done",
+};
+
+const STATUS_STYLE: Record<string, string> = {
+  pending: "bg-surface-100 text-surface-700",
+  in_progress: "bg-brand-100 text-brand-800",
+  done: "bg-success-50 text-success-600",
+};
+
+export default function PortalProgress({
+  portalId,
+  initialMilestones,
+  isAdmin,
+  portalStatus,
+  summary,
+  title,
+}: PortalProgressProps) {
+  const [milestones, setMilestones] = useState(initialMilestones);
+  const [metaStatus, setMetaStatus] = useState(portalStatus);
+  const [metaSummary, setMetaSummary] = useState(summary);
+  const [metaTitle, setMetaTitle] = useState(title);
+  const [newTitle, setNewTitle] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const doneCount = milestones.filter((m) => m.status === "done").length;
+  const progress =
+    milestones.length === 0
+      ? 0
+      : Math.round((doneCount / milestones.length) * 100);
+
+  const updateMilestone = async (
+    id: string,
+    patch: Partial<PortalMilestone>,
+  ) => {
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/portal/projects/${portalId}/milestones`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, ...patch }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Update failed");
+      setMilestones((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, ...data.milestone } : m)),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Update failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const addMilestone = async () => {
+    if (!newTitle.trim()) return;
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/portal/projects/${portalId}/milestones`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: newTitle }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Could not add");
+      setMilestones((prev) => [...prev, data.milestone]);
+      setNewTitle("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not add");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveMeta = async () => {
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/portal/projects/${portalId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: metaTitle,
+          summary: metaSummary,
+          status: metaStatus,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Could not save");
+      setMetaTitle(data.portal.title);
+      setMetaSummary(data.portal.summary);
+      setMetaStatus(data.portal.status);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-[28rem] flex-col rounded-2xl border border-surface-200 bg-surface-0">
+      <div className="border-b border-surface-200 px-5 py-4">
+        <h2 className="text-lg font-semibold text-surface-950">Progress</h2>
+        <p className="text-sm text-surface-700">
+          {isAdmin
+            ? "Update milestones so your client sees live status."
+            : "Track where your project is right now."}
+        </p>
+        <div className="mt-4">
+          <div className="mb-1 flex justify-between text-xs font-medium text-surface-700">
+            <span>
+              {doneCount} of {milestones.length} complete
+            </span>
+            <span>{progress}%</span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-surface-100">
+            <div
+              className="h-full rounded-full bg-brand-600 transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+        {isAdmin && (
+          <div className="space-y-3 rounded-xl border border-surface-200 bg-surface-50 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-surface-700">
+              Admin controls
+            </p>
+            <Input
+              id="portal-title"
+              label="Project title"
+              value={metaTitle}
+              onChange={(e) => setMetaTitle(e.target.value)}
+            />
+            <label className="block text-sm font-medium text-surface-900">
+              Status
+              <select
+                className="mt-1 w-full rounded-xl border border-surface-200 bg-surface-0 px-3 py-2 text-surface-950"
+                value={metaStatus}
+                onChange={(e) => setMetaStatus(e.target.value)}
+              >
+                <option value="active">Active</option>
+                <option value="paused">Paused</option>
+                <option value="completed">Completed</option>
+              </select>
+            </label>
+            <label className="block text-sm font-medium text-surface-900">
+              Summary for client
+              <textarea
+                className="mt-1 w-full rounded-xl border border-surface-200 bg-surface-0 px-3 py-2 text-sm text-surface-950"
+                rows={3}
+                value={metaSummary}
+                onChange={(e) => setMetaSummary(e.target.value)}
+              />
+            </label>
+            <Button
+              type="button"
+              variant="secondary"
+              loading={saving}
+              onClick={() => void saveMeta()}
+            >
+              Save project details
+            </Button>
+          </div>
+        )}
+
+        {!isAdmin && metaSummary && (
+          <p className="rounded-xl bg-brand-50 px-4 py-3 text-sm text-surface-800">
+            {metaSummary}
+          </p>
+        )}
+
+        <ol className="space-y-3">
+          {milestones.map((m, index) => (
+            <li
+              key={m.id}
+              className="rounded-xl border border-surface-200 px-4 py-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs font-medium text-surface-500">
+                    Step {index + 1}
+                  </div>
+                  <div className="font-semibold text-surface-950">{m.title}</div>
+                  {m.description && (
+                    <p className="mt-1 text-sm text-surface-700">
+                      {m.description}
+                    </p>
+                  )}
+                </div>
+                <span
+                  className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold ${STATUS_STYLE[m.status] || STATUS_STYLE.pending}`}
+                >
+                  {STATUS_LABEL[m.status] || m.status}
+                </span>
+              </div>
+              {isAdmin && (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {(["pending", "in_progress", "done"] as const).map((s) => (
+                    <button
+                      key={s}
+                      type="button"
+                      disabled={saving || m.status === s}
+                      onClick={() => void updateMilestone(m.id, { status: s })}
+                      className={`rounded-lg px-2.5 py-1 text-xs font-medium transition ${
+                        m.status === s
+                          ? "bg-brand-600 text-white"
+                          : "bg-surface-100 text-surface-700 hover:bg-surface-200"
+                      }`}
+                    >
+                      {STATUS_LABEL[s]}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </li>
+          ))}
+        </ol>
+
+        {isAdmin && (
+          <div className="flex gap-2">
+            <Input
+              id="new-milestone"
+              label="Add milestone"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              placeholder="e.g. Content review"
+            />
+            <div className="flex items-end">
+              <Button
+                type="button"
+                variant="secondary"
+                loading={saving}
+                onClick={() => void addMilestone()}
+              >
+                Add
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <p className="text-sm text-error-600" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/PortalWorkspace.tsx
+++ b/src/components/portal/PortalWorkspace.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import PortalChat, { type PortalMessage } from "@/components/portal/PortalChat";
+import PortalProgress, {
+  type PortalMilestone,
+} from "@/components/portal/PortalProgress";
+
+interface PortalWorkspaceProps {
+  portal: {
+    id: string;
+    title: string;
+    clientName: string;
+    clientEmail: string;
+    status: string;
+    summary: string;
+    milestones: PortalMilestone[];
+    messages: PortalMessage[];
+  };
+  isAdmin: boolean;
+}
+
+export default function PortalWorkspace({
+  portal,
+  isAdmin,
+}: PortalWorkspaceProps) {
+  const router = useRouter();
+
+  const logout = async () => {
+    await fetch("/api/portal/logout", { method: "POST" });
+    router.push("/portal");
+    router.refresh();
+  };
+
+  return (
+    <div className="mx-auto max-w-7xl px-6 py-8">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <Link
+            href="/portal/home"
+            className="text-sm font-medium text-brand-700 hover:underline"
+          >
+            ← All projects
+          </Link>
+          <h1 className="mt-2 text-3xl font-bold text-surface-950">
+            {portal.title}
+          </h1>
+          <p className="mt-1 text-sm text-surface-700">
+            {portal.clientName} · {portal.clientEmail}
+            {isAdmin ? " · editing as admin" : ""}
+          </p>
+        </div>
+        <Button type="button" variant="ghost" onClick={() => void logout()}>
+          Sign out
+        </Button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2 lg:items-stretch">
+        <PortalChat
+          portalId={portal.id}
+          initialMessages={portal.messages}
+          isAdmin={isAdmin}
+        />
+        <PortalProgress
+          portalId={portal.id}
+          initialMilestones={portal.milestones}
+          isAdmin={isAdmin}
+          portalStatus={portal.status}
+          summary={portal.summary}
+          title={portal.title}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -27,6 +27,7 @@ export const NAV_LINKS = [
   { href: "/services", label: "Services" },
   { href: "/about", label: "About" },
   { href: "/contact", label: "Contact" },
+  { href: "/portal", label: "Portal" },
 ] as const;
 
 export const BUDGET_OPTIONS = [

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -137,3 +137,44 @@ export async function sendServiceRequestNotification(input: {
 
   return { id: result?.id ?? "sent" };
 }
+
+export async function sendPortalOtpEmail(input: {
+  to: string;
+  code: string;
+}): Promise<{ id: string }> {
+  const resend = getResend();
+  if (!resend) {
+    throw new Error("Email is not configured (missing RESEND_API_KEY)");
+  }
+
+  const subject = "Your portal PIN — Adam Batten";
+  const text = [
+    `Your one-time portal PIN is: ${input.code}`,
+    ``,
+    `It expires in 10 minutes.`,
+    `If you did not request this, you can ignore this email.`,
+  ].join("\n");
+
+  const html = `
+    <div style="font-family: system-ui, sans-serif; line-height: 1.5; color: #0f172a;">
+      <h2 style="margin: 0 0 12px;">Your portal PIN</h2>
+      <p style="margin: 0 0 16px;">Use this code to open your project portal. It expires in <strong>10 minutes</strong>.</p>
+      <p style="margin: 0 0 16px; font-size: 32px; font-weight: 700; letter-spacing: 0.2em;">${escapeHtml(input.code)}</p>
+      <p style="margin: 0; color: #64748b; font-size: 14px;">If you did not request this, you can ignore this email.</p>
+    </div>
+  `;
+
+  const { data: result, error } = await resend.emails.send({
+    from: FROM_EMAIL,
+    to: [input.to],
+    subject,
+    text,
+    html,
+  });
+
+  if (error) {
+    throw new Error(error.message || "Failed to send portal PIN email");
+  }
+
+  return { id: result?.id ?? "sent" };
+}

--- a/src/lib/portal-auth.ts
+++ b/src/lib/portal-auth.ts
@@ -1,0 +1,185 @@
+import { createHash, randomBytes, randomInt, timingSafeEqual } from "crypto";
+import { cookies } from "next/headers";
+import { prisma } from "@/lib/db";
+import { CONTACT_TO_EMAIL } from "@/lib/email";
+
+export const PORTAL_COOKIE = "portal_session";
+const OTP_TTL_MS = 10 * 60 * 1000;
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_OTP_ATTEMPTS = 5;
+
+export function getAdminEmail(): string {
+  return (
+    process.env.ADMIN_EMAIL?.trim().toLowerCase() ||
+    CONTACT_TO_EMAIL.toLowerCase()
+  );
+}
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function isAdminEmail(email: string): boolean {
+  return normalizeEmail(email) === getAdminEmail();
+}
+
+function hashValue(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function safeEqualHex(a: string, b: string): boolean {
+  try {
+    const ba = Buffer.from(a, "hex");
+    const bb = Buffer.from(b, "hex");
+    if (ba.length !== bb.length) return false;
+    return timingSafeEqual(ba, bb);
+  } catch {
+    return false;
+  }
+}
+
+export function generateOtpCode(): string {
+  return String(randomInt(0, 1_000_000)).padStart(6, "0");
+}
+
+export async function createAndStoreOtp(email: string): Promise<string> {
+  const normalized = normalizeEmail(email);
+  const code = generateOtpCode();
+  const expiresAt = new Date(Date.now() + OTP_TTL_MS);
+
+  await prisma.portalOtp.deleteMany({ where: { email: normalized } });
+  await prisma.portalOtp.create({
+    data: {
+      email: normalized,
+      codeHash: hashValue(code),
+      expiresAt,
+    },
+  });
+
+  return code;
+}
+
+export async function verifyOtpCode(
+  email: string,
+  code: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const normalized = normalizeEmail(email);
+  const record = await prisma.portalOtp.findFirst({
+    where: { email: normalized },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (!record) {
+    return { ok: false, error: "No PIN found. Request a new one." };
+  }
+
+  if (record.expiresAt.getTime() < Date.now()) {
+    await prisma.portalOtp.delete({ where: { id: record.id } });
+    return { ok: false, error: "PIN expired. Request a new one." };
+  }
+
+  if (record.attempts >= MAX_OTP_ATTEMPTS) {
+    await prisma.portalOtp.delete({ where: { id: record.id } });
+    return { ok: false, error: "Too many attempts. Request a new PIN." };
+  }
+
+  const match = safeEqualHex(record.codeHash, hashValue(code.trim()));
+  if (!match) {
+    await prisma.portalOtp.update({
+      where: { id: record.id },
+      data: { attempts: { increment: 1 } },
+    });
+    return { ok: false, error: "Incorrect PIN. Try again." };
+  }
+
+  await prisma.portalOtp.delete({ where: { id: record.id } });
+  return { ok: true };
+}
+
+export async function createSession(email: string): Promise<string> {
+  const normalized = normalizeEmail(email);
+  const token = randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+
+  await prisma.portalSession.create({
+    data: {
+      tokenHash: hashValue(token),
+      email: normalized,
+      isAdmin: isAdminEmail(normalized),
+      expiresAt,
+    },
+  });
+
+  return token;
+}
+
+export async function destroySession(token: string | undefined): Promise<void> {
+  if (!token) return;
+  await prisma.portalSession.deleteMany({
+    where: { tokenHash: hashValue(token) },
+  });
+}
+
+export type PortalAuth = {
+  email: string;
+  isAdmin: boolean;
+};
+
+export async function getPortalAuth(): Promise<PortalAuth | null> {
+  const jar = await cookies();
+  const token = jar.get(PORTAL_COOKIE)?.value;
+  if (!token) return null;
+
+  const session = await prisma.portalSession.findUnique({
+    where: { tokenHash: hashValue(token) },
+  });
+
+  if (!session || session.expiresAt.getTime() < Date.now()) {
+    if (session) {
+      await prisma.portalSession.delete({ where: { id: session.id } });
+    }
+    return null;
+  }
+
+  return {
+    email: session.email,
+    isAdmin: session.isAdmin || isAdminEmail(session.email),
+  };
+}
+
+export async function setSessionCookie(token: string): Promise<void> {
+  const jar = await cookies();
+  jar.set(PORTAL_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_TTL_MS / 1000,
+  });
+}
+
+export async function clearSessionCookie(): Promise<void> {
+  const jar = await cookies();
+  jar.delete(PORTAL_COOKIE);
+}
+
+export async function emailCanAccessPortal(email: string): Promise<boolean> {
+  const normalized = normalizeEmail(email);
+  if (isAdminEmail(normalized)) return true;
+  const count = await prisma.clientPortal.count({
+    where: { clientEmail: normalized },
+  });
+  return count > 0;
+}
+
+export async function assertPortalAccess(
+  portalId: string,
+  auth: PortalAuth,
+): Promise<boolean> {
+  if (auth.isAdmin) return true;
+  const portal = await prisma.clientPortal.findUnique({
+    where: { id: portalId },
+    select: { clientEmail: true },
+  });
+  return Boolean(portal && portal.clientEmail === auth.email);
+}

--- a/src/lib/portal-validations.ts
+++ b/src/lib/portal-validations.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const portalOtpRequestSchema = z.object({
+  email: z.string().email("Enter a valid email address"),
+});
+
+export const portalOtpVerifySchema = z.object({
+  email: z.string().email("Enter a valid email address"),
+  code: z
+    .string()
+    .trim()
+    .regex(/^\d{6}$/, "Enter the 6-digit PIN from your email"),
+});
+
+export const portalCreateSchema = z.object({
+  title: z.string().min(3, "Title is required"),
+  clientName: z.string().min(2, "Client name is required"),
+  clientEmail: z.string().email("Valid client email required"),
+  summary: z.string().optional(),
+  milestones: z
+    .array(
+      z.object({
+        title: z.string().min(2),
+        description: z.string().optional(),
+      }),
+    )
+    .optional(),
+});
+
+export const portalMessageSchema = z.object({
+  body: z.string().trim().min(1, "Message cannot be empty").max(4000),
+});
+
+export const portalMilestoneUpdateSchema = z.object({
+  title: z.string().min(2).optional(),
+  description: z.string().optional(),
+  status: z.enum(["pending", "in_progress", "done"]).optional(),
+  order: z.number().int().optional(),
+});
+
+export const portalMilestoneCreateSchema = z.object({
+  title: z.string().min(2),
+  description: z.string().optional(),
+  status: z.enum(["pending", "in_progress", "done"]).optional(),
+});
+
+export const portalMetaUpdateSchema = z.object({
+  title: z.string().min(3).optional(),
+  summary: z.string().optional(),
+  status: z.enum(["active", "paused", "completed"]).optional(),
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Passwordless **client portal** for projects once work begins:

- Email a **6-digit PIN** (no accounts/passwords); **Forgot PIN** sends a new code
- One workspace page: **Messages** (left) + **Progress milestones** (right)
- **Admin** (`ADMIN_EMAIL` / `adambatten@live.co.uk`) sees the same screen with edit controls, and can create portals from `/portal/home`
- Clients only see portals tied to their email

## How you use it
1. Sign in at `/portal` with your admin email → get a PIN
2. Create a portal (client name + email + title)
3. Tell the client to open `/portal` with their email
4. Update milestones on the progress column; chat on the left

## Setup
Requires `RESEND_API_KEY` (same as contact form) so PINs actually email. Demo seed client: `client@example.com` (local/dev shows PIN on screen when Resend is off).

## Test plan
- [x] Unit tests
- [x] Playwright portal OTP flow
- [ ] With Resend: admin + client receive real PIN emails
- [ ] Admin can flip milestone statuses; client sees updates after refresh/poll

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89d9ab7-0928-41f7-ad5e-f6922c8ad97d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89d9ab7-0928-41f7-ad5e-f6922c8ad97d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

